### PR TITLE
Add network management and commit methods

### DIFF
--- a/main.go
+++ b/main.go
@@ -255,6 +255,9 @@ type Ban_settings_t struct {
 	Description            string   `bson:"description" json:"description" fastnetmon_type:"string"`
 	Networks               []string `bson:"networks" json:"networks" fastnetmon_type:"cidr_networks_list"`
 	Enable_ban             bool     `bson:"enable_ban" json:"enable_ban" fastnetmon_type:"bool"`
+	Enable_ban_incoming    bool     `bson:"enable_ban_incoming" json:"enable_ban_incoming" fastnetmon_type:"bool"`
+	Enable_ban_outgoing    bool     `bson:"enable_ban_outgoing" json:"enable_ban_outgoing" fastnetmon_type:"bool"`
+	Calculation_method     string   `bson:"calculation_method" json:"calculation_method" fastnetmon_type:"string"`
 	Ban_for_pps            bool     `bson:"ban_for_pps" json:"ban_for_pps" fastnetmon_type:"bool"`
 	Ban_for_bandwidth      bool     `bson:"ban_for_bandwidth" json:"ban_for_bandwidth" fastnetmon_type:"bool"`
 	Ban_for_flows          bool     `bson:"ban_for_flows" json:"ban_for_flows" fastnetmon_type:"bool"`

--- a/main.go
+++ b/main.go
@@ -549,6 +549,86 @@ func (client *FastNetMonClient) GetNetworks() ([]string, error) {
 	return networks_response.Values, nil
 }
 
+func (client *FastNetMonClient) AddNetwork(cidr string) error {
+	encoded := strings.Replace(cidr, "/", "%2f", 1)
+	resp, err := grequests.Put(client.Prefix+"/main/networks_list/"+encoded, grequests.FromRequestOptions(client.Ro))
+
+	if err != nil {
+		return fmt.Errorf("Cannot connect to API: %w", err)
+	}
+
+	if !resp.Ok {
+		if resp.StatusCode == 401 {
+			return errors.New("Auth denied")
+		}
+		return fmt.Errorf("Did not return OK: %d", resp.StatusCode)
+	}
+
+	response := ErrorJson{}
+	if err := resp.JSON(&response); err != nil {
+		return err
+	}
+
+	if !response.Success {
+		return fmt.Errorf("API error: %s", response.ErrorText)
+	}
+
+	return nil
+}
+
+func (client *FastNetMonClient) RemoveNetwork(cidr string) error {
+	encoded := strings.Replace(cidr, "/", "%2f", 1)
+	resp, err := grequests.Delete(client.Prefix+"/main/networks_list/"+encoded, grequests.FromRequestOptions(client.Ro))
+
+	if err != nil {
+		return fmt.Errorf("Cannot connect to API: %w", err)
+	}
+
+	if !resp.Ok {
+		if resp.StatusCode == 401 {
+			return errors.New("Auth denied")
+		}
+		return fmt.Errorf("Did not return OK: %d", resp.StatusCode)
+	}
+
+	response := ErrorJson{}
+	if err := resp.JSON(&response); err != nil {
+		return err
+	}
+
+	if !response.Success {
+		return fmt.Errorf("API error: %s", response.ErrorText)
+	}
+
+	return nil
+}
+
+func (client *FastNetMonClient) Commit() error {
+	resp, err := grequests.Put(client.Prefix+"/commit", grequests.FromRequestOptions(client.Ro))
+
+	if err != nil {
+		return fmt.Errorf("Cannot connect to API: %w", err)
+	}
+
+	if !resp.Ok {
+		if resp.StatusCode == 401 {
+			return errors.New("Auth denied")
+		}
+		return fmt.Errorf("Did not return OK: %d", resp.StatusCode)
+	}
+
+	response := ErrorJson{}
+	if err := resp.JSON(&response); err != nil {
+		return err
+	}
+
+	if !response.Success {
+		return fmt.Errorf("API error: %s", response.ErrorText)
+	}
+
+	return nil
+}
+
 // Retrieves all host groups
 func (client *FastNetMonClient) GetAllHostgroups() ([]Ban_settings_t, error) {
 	resp, err := grequests.Get(client.Prefix+"/hostgroup", grequests.FromRequestOptions(client.Ro))


### PR DESCRIPTION
## Summary

This PR adds first-class methods for managing the global `networks_list` and committing configuration changes via the FastNetMon web API.

## New Methods

| Method | HTTP | Endpoint | Description |
|--------|------|----------|-------------|
| `AddNetwork(cidr)` | PUT | `/main/networks_list/<cidr>` | Add a network to the global networks list |
| `RemoveNetwork(cidr)` | DELETE | `/main/networks_list/<cidr>` | Remove a network from the global networks list |
| `Commit()` | PUT | `/commit` | Commit pending configuration changes |

## Motivation

The existing client exposes `GetNetworks()` to read the networks list but provides no way to mutate it or commit changes. Callers currently have to construct raw HTTP requests using the client's internal `Prefix` and `Ro` fields directly, which breaks encapsulation.

These three methods complete the networks lifecycle and allow callers to manage networks entirely through the client's public API, consistent with how host groups, flow spec rules, and remote blackhole entries are already handled.